### PR TITLE
Unit categories

### DIFF
--- a/gui/include/gui/navutil.h
+++ b/gui/include/gui/navutil.h
@@ -66,7 +66,6 @@ extern MyConfig *pConfig; /**< Global instance */
 class canvasConfig;  // circular
 
 bool LogMessageOnce(const wxString &msg);
-double fromUsrDistance(double usr_distance, int unit = -1);
 double fromUsrSpeed(double usr_speed, int unit = -1);
 double fromUsrWindSpeed(double usr_wspeed, int unit = -1);
 double fromUsrTemp(double usr_temp, int unit = -1);

--- a/gui/include/gui/options.h
+++ b/gui/include/gui/options.h
@@ -181,6 +181,7 @@ enum {
   ID_SPEEDUNITSCHOICE,
   ID_WINDSPEEDUNITCHOICE,
   ID_DEPTHUNITSCHOICE,
+  ID_HEIGHTUNITSCHOICE,
   ID_SELECTLIST,
   ID_SHOWDEPTHUNITSBOX1,
   ID_SHOWGPSWINDOW,
@@ -477,7 +478,7 @@ public:
 
   // For "Units" page
   wxChoice *pSDMMFormat, *pDistanceFormat, *pSpeedFormat, *pDepthUnitSelect,
-      *pTempFormat, *pWindSpeedFormat;
+      *pTempFormat, *pWindSpeedFormat, *pHeightUnitSelect;
   wxCheckBox *pCBTrueShow, *pCBMagShow;
   wxTextCtrl *pMagVar;
 

--- a/gui/src/TCWin.cpp
+++ b/gui/src/TCWin.cpp
@@ -12,6 +12,7 @@
 #include "chcanv.h"
 #include "tide_time.h"
 #include "tcmgr.h"
+#include "TCDataFactory.h"
 #include "dychart.h"
 #include "model/cutil.h"
 #include "font_mgr.h"
@@ -528,6 +529,19 @@ void TCWin::PaintChart(wxDC &dc, const wxRect &chartRect) {
       int tt = tt_localtz + (i * FORWARD_ONE_HOUR_STEP);
       ptcmgr->GetTideOrCurrent(tt, pIDX->IDX_rec_num, tcv[i], dir);
       tt_tcv[i] = tt;  // store the corresponding time_t value
+
+      // Convert tide values from station units to user's height units
+      Station_Data *pmsd = pIDX->pref_sta_data;
+      if (pmsd) {
+        // Convert from station units to meters first
+        int unit_c = TCDataFactory::findunit(pmsd->unit);
+        if (unit_c >= 0) {
+          tcv[i] = tcv[i] * TCDataFactory::known_units[unit_c].conv_factor;
+        }
+        // Now convert from meters to preferred height units
+        tcv[i] = toUsrHeight(tcv[i]);
+      }
+
       if (tcv[i] > tcmax) tcmax = tcv[i];
       if (tcv[i] < tcmin) tcmin = tcv[i];
 
@@ -547,10 +561,26 @@ void TCWin::PaintChart(wxDC &dc, const wxRect &chartRect) {
               tcd.Set(tctime + (m_stationOffset_mins - m_diff_mins) * 60);
 
             s.Printf(tcd.Format("%H:%M  "));
-            s1.Printf("%05.2f ", tcvalue);  // write value
+
+            // Convert tcvalue to preferred height units (it comes from
+            // GetHightOrLowTide in station units)
+            double tcvalue_converted = tcvalue;
+            Station_Data *pmsd = pIDX->pref_sta_data;
+            if (pmsd) {
+              // Convert from station units to meters first
+              int unit_c = TCDataFactory::findunit(pmsd->unit);
+              if (unit_c >= 0) {
+                tcvalue_converted =
+                    tcvalue_converted *
+                    TCDataFactory::known_units[unit_c].conv_factor;
+              }
+              // Now convert from meters to preferred height units
+              tcvalue_converted = toUsrHeight(tcvalue_converted);
+            }
+
+            s1.Printf("%05.2f ", tcvalue_converted);  // write converted value
             s.Append(s1);
-            Station_Data *pmsd = pIDX->pref_sta_data;  // write unit
-            if (pmsd) s.Append(wxString(pmsd->units_abbrv, wxConvUTF8));
+            s.Append(getUsrHeightUnit());
             s.Append("   ");
             (wt) ? s.Append(_("HW")) : s.Append(_("LW"));  // write HW or LT
 
@@ -574,10 +604,10 @@ void TCWin::PaintChart(wxDC &dc, const wxRect &chartRect) {
           thx.Set((time_t)tt + (m_stationOffset_mins - m_diff_mins) * 60);
 
         s.Printf(thx.Format("%H:%M  "));
-        s1.Printf("%05.2f ", fabs(tcv[i]));  // write value
+        s1.Printf("%05.2f ",
+                  fabs(tcv[i]));  // tcv[i] is already converted to height units
         s.Append(s1);
-        Station_Data *pmsd = pIDX->pref_sta_data;  // write unit
-        if (pmsd) s.Append(wxString(pmsd->units_abbrv, wxConvUTF8));
+        s.Append(getUsrHeightUnit());
         s1.Printf("  %03.0f", dir);  // write direction
         s.Append(s1);
 
@@ -722,8 +752,10 @@ void TCWin::PaintChart(wxDC &dc, const wxRect &chartRect) {
 
   Station_Data *pmsd = pIDX->pref_sta_data;
   if (pmsd) {
-    dc.GetTextExtent(wxString(pmsd->units_conv, wxConvUTF8), &w, &h);
-    dc.DrawRotatedText(wxString(pmsd->units_conv, wxConvUTF8), 5,
+    // Use user's height unit for Y-axis label instead of station units
+    wxString height_unit = getUsrHeightUnit();
+    dc.GetTextExtent(height_unit, &w, &h);
+    dc.DrawRotatedText(height_unit, 5,
                        m_graph_rect.y + m_graph_rect.height / 2 + w / 2, 90.);
   }
 
@@ -1130,14 +1162,26 @@ void TCWin::OnTCWinPopupTimerEvent(wxTimerEvent &event) {
 
     // set tide level or current speed at that time
     ptcmgr->GetTideOrCurrent(tts, pIDX->IDX_rec_num, t, d);
-    s.Printf("%3.2f ", (t < 0 && CURRENT_PLOT == m_plot_type)
-                           ? -t
-                           : t);  // always positive if current
+
+    // Convert tide/current value to preferred height units
+    double t_converted = (t < 0 && CURRENT_PLOT == m_plot_type) ? -t : t;
+    Station_Data *pmsd = pIDX->pref_sta_data;
+    if (pmsd) {
+      // Convert from station units to meters first
+      int unit_c = TCDataFactory::findunit(pmsd->unit);
+      if (unit_c >= 0) {
+        t_converted =
+            t_converted * TCDataFactory::known_units[unit_c].conv_factor;
+      }
+      // Now convert from meters to preferred height units
+      t_converted = toUsrHeight(t_converted);
+    }
+
+    s.Printf("%3.2f ", t_converted);
     p.Append(s);
 
-    // set unit
-    Station_Data *pmsd = pIDX->pref_sta_data;
-    if (pmsd) p.Append(wxString(pmsd->units_abbrv, wxConvUTF8));
+    // set unit - use preferred height unit abbreviation
+    p.Append(getUsrHeightUnit());
 
     // set current direction
     if (CURRENT_PLOT == m_plot_type) {

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -615,6 +615,7 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   Read("WindSpeedFormat",
        &g_iWindSpeedFormat);  // 0 = "knots"), 1 = "m/s", 2 = "Mph", 3 = "km/h"
   Read("TemperatureFormat", &g_iTempFormat);  // 0 = C, 1 = F, 2 = K
+  Read("HeightFormat", &g_iHeightFormat);     // 0 = M, 1 = FT
 
   // LIVE ETA OPTION
   Read("LiveETA", &g_bShowLiveETA);
@@ -1991,6 +1992,7 @@ void MyConfig::UpdateSettings() {
     Write("WindSpeedFormat", g_iWindSpeedFormat);
     Write("ShowDepthUnits", g_bShowDepthUnits);
     Write("TemperatureFormat", g_iTempFormat);
+    Write("HeightFormat", g_iHeightFormat);
   }
   Write("GPSIdent", g_GPS_Ident);
   Write("ActiveRoute", g_active_route);
@@ -2799,7 +2801,7 @@ void SwitchInlandEcdisMode(bool Switch) {
   if (Switch) {
     wxLogMessage("Switch InlandEcdis mode On");
     LoadS57();
-    // Overule some sewttings to comply with InlandEcdis
+    // Overrule some settings to comply with InlandEcdis
     // g_toolbarConfig = ".....XXXX.X...XX.XXXXXXXXXXXX";
     g_iDistanceFormat = 2;  // 0 = "Nautical miles"), 1 = "Statute miles", 2 =
                             // "Kilometers", 3 = "Meters"
@@ -2816,6 +2818,7 @@ void SwitchInlandEcdisMode(bool Switch) {
       pConfig->Read("DistanceFormat", &g_iDistanceFormat);
       pConfig->Read("SpeedFormat", &g_iSpeedFormat);
       pConfig->Read("ShowDepthUnits", &g_bShowDepthUnits, 1);
+      pConfig->Read("HeightFormat", &g_iHeightFormat);
       int read_int;
       pConfig->Read("nDisplayCategory", &read_int, (enum _DisCat)STANDARD);
       if (ps52plib) ps52plib->SetDisplayCategory((enum _DisCat)read_int);
@@ -2941,31 +2944,6 @@ wxDateTime fromUsrDateTime(const wxDateTime ts, const int format,
   return dt;
 }
 
-/**************************************************************************/
-/*          Converts the distance from the units selected by user to NMi  */
-/**************************************************************************/
-double fromUsrDistance(double usr_distance, int unit) {
-  double ret = NAN;
-  if (unit == -1) unit = g_iDistanceFormat;
-  switch (unit) {
-    case DISTANCE_NMI:  // Nautical miles
-      ret = usr_distance;
-      break;
-    case DISTANCE_MI:  // Statute miles
-      ret = usr_distance / 1.15078;
-      break;
-    case DISTANCE_KM:
-      ret = usr_distance / 1.852;
-      break;
-    case DISTANCE_M:
-      ret = usr_distance / 1852;
-      break;
-    case DISTANCE_FT:
-      ret = usr_distance / 6076.12;
-      break;
-  }
-  return ret;
-}
 /**************************************************************************/
 /*          Converts the speed from the units selected by user to knots   */
 /**************************************************************************/

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -718,6 +718,19 @@ double fromUsrDepth_Plugin(double usr_depth, int unit) {
 
 wxString getUsrDepthUnit_Plugin(int unit) { return getUsrDepthUnit(unit); }
 
+/**
+ * Height Conversion Functions
+ */
+double toUsrHeight_Plugin(double m_height, int unit) {
+  return toUsrHeight(m_height, unit);
+}
+
+double fromUsrHeight_Plugin(double usr_height, int unit) {
+  return fromUsrHeight(usr_height, unit);
+}
+
+wxString getUsrHeightUnit_Plugin(int unit) { return getUsrHeightUnit(unit); }
+
 double fromDMM_PlugIn(wxString sdms) { return fromDMM(sdms); }
 
 bool PlugIn_GSHHS_CrossesLand(double lat1, double lon1, double lat2,

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -3181,6 +3181,35 @@ extern DECL_EXP double toUsrDepth_Plugin(double m_depth, int unit = -1);
 extern DECL_EXP double fromUsrDepth_Plugin(double usr_depth, int unit = -1);
 
 /**
+ * Gets display string for user's preferred height unit.
+ *
+ * @param unit Override unit choice (-1 for user preference):
+ *             0=meters, 1=feet
+ * @return Localized unit string (e.g. "m", "ft")
+ */
+extern DECL_EXP wxString getUsrHeightUnit_Plugin(int unit = -1);
+
+/**
+ * Converts meters to user's preferred height unit.
+ *
+ * @param m_height Height in meters
+ * @param unit Override unit choice (-1 for user preference):
+ *             0=meters, 1=feet
+ * @return Height in user's preferred unit
+ */
+extern DECL_EXP double toUsrHeight_Plugin(double m_height, int unit = -1);
+
+/**
+ * Converts from user's preferred height unit to meters.
+ *
+ * @param usr_height Height in user's unit
+ * @param unit Override unit choice (-1 for user preference):
+ *             0=meters, 1=feet
+ * @return Height in meters
+ */
+extern DECL_EXP double fromUsrHeight_Plugin(double usr_height, int unit = -1);
+
+/**
  * Parse a formatted coordinate string to get decimal degrees.
  *
  * Attempt to parse a wide variety of formatted coordinate

--- a/libs/s52plib/src/s52cnsy.cpp
+++ b/libs/s52plib/src/s52cnsy.cpp
@@ -2694,12 +2694,12 @@ wxString SNDFRM02(S57Obj *obj, double depth_value_in)
 
   switch (ps52plib->m_nDepthUnitDisplay) {
     case 0:
-      depth_value = depth_value * 3 * 39.37 / 36;  // feet
-      safety_depth = safety_depth * 3 * 39.37 / 36;
+      depth_value = depth_value * (1.0 / 0.3048);  // feet
+      safety_depth = safety_depth * (1.0 / 0.3048);
       break;
     case 2:
-      depth_value = depth_value * 3 * 39.37 / (36 * 6);  // fathoms
-      safety_depth = safety_depth * 3 * 39.37 / (36 * 6);
+      depth_value = depth_value * (1.0 / 0.3048) / 6;  // fathoms
+      safety_depth = safety_depth * (1.0 / 0.3048) / 6;
       break;
     default:
       break;
@@ -3816,14 +3816,10 @@ static wxString _LITDSN01(S57Obj *obj)
 
   if (UNKNOWN != height) {
     wxString s;
-    switch (ps52plib->m_nDepthUnitDisplay) {
-      case 0:  // feet
-      case 2:  // fathoms
-        s.Printf(_T("%3.0fft"), height * 3 * 39.37 / 36);
-        break;
-      default:
-        s.Printf(_T("%3.0fm"), height);
-        break;
+    if (ps52plib->m_nHeightUnitDisplay == 1) { // feet
+      s.Printf(_T("%3.0fft"), height * (1.0 / 0.3048));
+    } else { // meters
+      s.Printf(_T("%3.0fm"), height);
     }
 
     s.Trim(false);  // remove leading spaces

--- a/libs/s52plib/src/s52plib.cpp
+++ b/libs/s52plib/src/s52plib.cpp
@@ -309,7 +309,8 @@ s52plib::s52plib(const wxString &PLib, bool b_forceLegacy) {
   m_nSymbolStyle = PAPER_CHART;
   m_nBoundaryStyle = PLAIN_BOUNDARIES;
   m_nDisplayCategory = OTHER;
-  m_nDepthUnitDisplay = 1;  // metres
+  m_nDepthUnitDisplay = 1;  // meters
+  m_nHeightUnitDisplay = 0; // meters
 
   UpdateMarinerParams();
 
@@ -1505,21 +1506,19 @@ char *s52plib::_getParamVal(ObjRazRules *rzRules, char *str, char *buf, int bsz)
       return NULL;  // abort
     }
   } else {
-    //    Special case for conversion of some vertical (height) attributes to
-    //    feet
+    // Special case for conversion of vertical (height) attributes.
+    // Inputs are meters; convert to user's height unit (meters/feet) as selected in s52plib.
     if ((!strncmp(buf, "VERCLR", 6)) || (!strncmp(buf, "VERCCL", 6)) ||
-        (!strncmp(buf, "VERCOP", 6)) || (!strncmp(buf, "ELEVAT", 6)) ) {
-      switch (m_nDepthUnitDisplay) {
-        case 0:  // feet
-        case 2:  // fathoms
-          double ft_val;
-          value.ToDouble(&ft_val);
-          ft_val = ft_val * 3 * 39.37 / 36;  // feet
-          value.Printf(_T("%4.1f"), ft_val);
-          break;
-        default:
-          break;
-      }
+        (!strncmp(buf, "VERCOP", 6)) || (!strncmp(buf, "ELEVAT", 6)) ||
+        (!strncmp(buf, "HEIGHT", 6)) ) {
+        if(m_nHeightUnitDisplay == 1) { // feet
+            double h_val_m;
+            if(value.ToDouble(&h_val_m)){
+                double ft_val = h_val_m * 3.280839895013123; // meters to feet
+                value.Printf(_T("%4.1f"), ft_val);
+            }
+        }
+        // else meters: leave as-is
     }
 
     // special case when ENC returns an index for particular attribute types
@@ -9923,6 +9922,16 @@ void s52plib::PLIB_LoadS57GlobalConfig(wxFileConfig *pconfig)
     read_int = wxMax(read_int, 0);                      // qualify value
     read_int = wxMin(read_int, 2);
     m_nDepthUnitDisplay = read_int;
+
+  // Load height unit display (meters/feet) from core HeightFormat if available
+  // Default to meters (0). Values correspond to HEIGHT_* enum: 0=M, 1=FT
+  if(pconfig->Read( _T ( "HeightFormat" ), &read_int, 0 )){
+    read_int = wxMax(read_int, 0);
+    read_int = wxMin(read_int, 1);
+    m_nHeightUnitDisplay = read_int;
+  } else {
+    m_nHeightUnitDisplay = 0;
+  }
 
 }
 

--- a/libs/s52plib/src/s52plib.h
+++ b/libs/s52plib/src/s52plib.h
@@ -370,6 +370,9 @@ public:
   int m_VersionMinor;
 
   int m_nDepthUnitDisplay;
+  // Preferred display unit for vertical heights (meters/feet).
+  // 0 = meters, 1 = feet
+  int m_nHeightUnitDisplay;
 
   //    Library data
   wxArrayPtrVoid *pAlloc;

--- a/model/include/model/config_vars.h
+++ b/model/include/model/config_vars.h
@@ -167,13 +167,33 @@ extern int g_detailslider_dialog_y;
 extern int g_ENCSoundingScaleFactor;
 extern int g_ENCTextScaleFactor;
 extern int g_GUIScaleFactor;
+/**
+ * User-selected distance (horizontal) unit format for display and input.
+ * Values correspond to DISTANCE_* enum (e.g., NMi, mi, km, m, ft, yd, etc.).
+ */
 extern int g_iDistanceFormat;
 extern int g_iENCToolbarPosX;
 extern int g_iENCToolbarPosY;
+/**
+ * User-selected height (vertical, above reference datum) unit format for
+ * display and input. Values correspond to HEIGHT_* enum (e.g., meters, feet).
+ * Used for tide levels, bridge clearances, and other height displays.
+ */
+extern int g_iHeightFormat;
 extern int g_iNavAidRadarRingsNumberVisible;
 extern int g_iSDMMFormat;
 extern int g_iSoundDeviceIndex;
+/**
+ * User-selected speed unit format for display and input.
+ * Values correspond to SPEED_* enum (e.g., knots, mph, km/h, m/s).
+ * Used for ownship speed, route planning, and other speed displays.
+ */
 extern int g_iSpeedFormat;
+/**
+ * User-selected temperature unit format for display and input.
+ * Values correspond to TEMPERATURE_* enum (e.g., Celsius, Fahrenheit, Kelvin).
+ * Used for weather overlays, tide info, and other temperature displays.
+ */
 extern int g_iTempFormat;
 extern int g_iWaypointRangeRingsNumber;
 extern int g_iWaypointRangeRingsStepUnits;
@@ -199,6 +219,11 @@ extern int g_nbrightness;
 extern int g_nCacheLimit;
 extern int g_nCOMPortCheck;
 extern int g_nCPUCount;
+/**
+ * User-selected depth (below surface) unit format for display and input.
+ * Values correspond to DEPTH_* enum (e.g., meters, feet, fathoms).
+ * Used for chart soundings, depth contours, and other depth displays.
+ */
 extern int g_nDepthUnitDisplay;
 extern int g_netmask_bits;
 extern int g_nframewin_posx;

--- a/model/include/model/navutil_base.h
+++ b/model/include/model/navutil_base.h
@@ -36,6 +36,9 @@
 enum { SPEED_KTS = 0, SPEED_MPH, SPEED_KMH, SPEED_MS };
 enum { WSPEED_KTS = 0, WSPEED_MS, WSPEED_MPH, WSPEED_KMH };
 enum { DEPTH_FT = 0, DEPTH_M, DEPTH_FA };
+/** Height unit format constants for vertical measurements above reference datum
+ */
+enum { HEIGHT_M = 0, HEIGHT_FT };
 enum { TEMPERATURE_C = 0, TEMPERATURE_F = 1, TEMPERATURE_K = 2 };
 
 enum {
@@ -55,17 +58,65 @@ extern double toUsrWindSpeed(double kts_speed, int unit = -1);
 extern wxString getUsrSpeedUnit(int unit = -1);
 extern wxString getUsrWindSpeedUnit(int unit = -1);
 extern wxString getUsrTempUnit(int unit = -1);
+/**
+ * Format a distance (given in nautical miles) using the current distance
+ * preference, adapting unit and precision for readability when appropriate.
+ *
+ * - Interprets `distance` as nautical miles (NMi).
+ * - Applies the user's distance preference when converting and formatting.
+ * - May adjust the displayed unit and numeric precision based on magnitude to
+ *   improve readability.
+ *
+ * @param distance Distance in nautical miles to format.
+ * @return Localized string containing the numeric value and unit.
+ */
 extern wxString FormatDistanceAdaptive(double distance);
+/**
+ * Convert a temperature from Celsius to user display units.
+ *
+ * @param cel_temp Temperature in Celsius to convert.
+ * @param unit Output unit or -1 to use the global temperature format.
+ * @return Converted temperature in the selected unit, or NaN on error.
+ */
 extern double toUsrTemp(double cel_temp, int unit = -1);
 
+/**
+ * Convert a distance from nautical miles (NMi) to user display units.
+ *
+ * @param nm_distance Distance in nautical miles to convert.
+ * @param unit Output unit or -1 to use the global distance format.
+ * @return Converted distance in the selected unit, or NaN on error.
+ */
 extern double toUsrDistance(double nm_distance, int unit = -1);
 extern wxString getUsrDistanceUnit(int unit = -1);
-extern double fromUsrDistance(double usr_distance, int unit, int default_val);
+/**
+ * Convert distance from user units to nautical miles.
+ *
+ * @param usr_distance Distance in user units
+ * @param unit Unit to convert from, or -1 to use default_val
+ * @param default_val Default unit when unit=-1, or -1 to use the global default
+ */
+extern double fromUsrDistance(double usr_distance, int unit,
+                              int default_val = -1);
 extern double fromUsrSpeed(double usr_speed, int unit, int default_val);
 
-extern double toUsrDepth(double cel_depth, int unit = -1);
+/**
+ * Convert a depth from meters to user display units.
+ *
+ * @param m_depth Depth in meters to convert.
+ * @param unit Output unit or -1 to use the global depth format.
+ * @return Converted depth in the selected unit, or NaN on error.
+ */
+extern double toUsrDepth(double m_depth, int unit = -1);
 extern double fromUsrDepth(double usr_depth, int unit = -1);
 extern wxString getUsrDepthUnit(int unit = -1);
+
+/** Convert height from meters to preferred height units */
+extern double toUsrHeight(double m_height, int unit = -1);
+/** Convert height from preferred height units to meters */
+extern double fromUsrHeight(double usr_height, int unit = -1);
+/** Get the abbreviation for the preferred height unit */
+extern wxString getUsrHeightUnit(int unit = -1);
 
 /**
  * This function parses a string containing a GPX time representation

--- a/model/src/config_vars.cpp
+++ b/model/src/config_vars.cpp
@@ -163,6 +163,7 @@ int g_GUIScaleFactor = 0;
 int g_iDistanceFormat = 0;
 int g_iENCToolbarPosX = 0;
 int g_iENCToolbarPosY = 0;
+int g_iHeightFormat = 0;
 int g_iNavAidRadarRingsNumberVisible = 0;
 int g_iSDMMFormat = 0;
 int g_iSoundDeviceIndex = 0;

--- a/model/src/navutil_base.cpp
+++ b/model/src/navutil_base.cpp
@@ -198,9 +198,6 @@ double toUsrWindSpeed(double kts_wspeed, int unit) {
   return ret;
 }
 
-/**************************************************************************/
-/*          Converts the distance to the units selected by user           */
-/**************************************************************************/
 double toUsrDistance(double nm_distance, int unit) {
   double ret = NAN;
   if (unit == -1) unit = g_iDistanceFormat;
@@ -406,7 +403,10 @@ double fromUsrSpeed(double usr_speed, int unit, int default_val) {
 /**************************************************************************/
 double fromUsrDistance(double usr_distance, int unit, int default_val) {
   double ret = NAN;
-  if (unit == -1) unit = default_val;
+  if (unit == -1) {
+    // Use g_iDistanceFormat as default when default_val is -1
+    unit = (default_val == -1) ? g_iDistanceFormat : default_val;
+  }
   switch (unit) {
     case DISTANCE_NMI:  // Nautical miles
       ret = usr_distance;
@@ -423,25 +423,31 @@ double fromUsrDistance(double usr_distance, int unit, int default_val) {
     case DISTANCE_FT:
       ret = usr_distance / 6076.12;
       break;
+    case DISTANCE_FA:
+      ret = usr_distance / 1012.68591;
+      break;
+    case DISTANCE_IN:
+      ret = usr_distance / 72913.4;
+      break;
+    case DISTANCE_CM:
+      ret = usr_distance / 185200;
+      break;
   }
   return ret;
 }
 
-/**************************************************************************/
-/*    Converts the depth in meters to the units selected by user          */
-/**************************************************************************/
-double toUsrDepth(double cel_depth, int unit) {
+double toUsrDepth(double m_depth, int unit) {
   double ret = NAN;
   if (unit == -1) unit = g_nDepthUnitDisplay;
   switch (unit) {
     case DEPTH_FT:  // Feet
-      ret = cel_depth / 0.3048;
+      ret = m_depth / 0.3048;
       break;
     case DEPTH_M:  // Meters
-      ret = cel_depth;
+      ret = m_depth;
       break;
     case DEPTH_FA:
-      ret = cel_depth / 0.3048 / 6;
+      ret = m_depth / 0.3048 / 6;
       break;
   }
   return ret;
@@ -482,6 +488,48 @@ wxString getUsrDepthUnit(int unit) {
       break;
     case DEPTH_FA:  // Fathoms
       ret = _("fa");
+      break;
+  }
+  return ret;
+}
+
+double toUsrHeight(double m_height, int unit) {
+  double ret = NAN;
+  if (unit == -1) unit = g_iHeightFormat;
+  switch (unit) {
+    case HEIGHT_M:  // Meters
+      ret = m_height;
+      break;
+    case HEIGHT_FT:  // Feet
+      ret = m_height / 0.3048;
+      break;
+  }
+  return ret;
+}
+
+double fromUsrHeight(double usr_height, int unit) {
+  double ret = NAN;
+  if (unit == -1) unit = g_iHeightFormat;
+  switch (unit) {
+    case HEIGHT_M:  // Meters
+      ret = usr_height;
+      break;
+    case HEIGHT_FT:  // Feet
+      ret = usr_height * 0.3048;
+      break;
+  }
+  return ret;
+}
+
+wxString getUsrHeightUnit(int unit) {
+  wxString ret;
+  if (unit == -1) unit = g_iHeightFormat;
+  switch (unit) {
+    case HEIGHT_M:  // Meters
+      ret = _("m");
+      break;
+    case HEIGHT_FT:  // Feet
+      ret = _("ft");
       break;
   }
   return ret;


### PR DESCRIPTION
WIP - will expose in upstream when it's ready.

# Overview

Implement #4772 (unit categorization) and #4735 (tide display units), plus fixes several related bugs discovered during implementation.

# Feature Changes

1. Unit Categorization: Restructured Options > Settings > Display units into logical categories:
   - Distance (horizontal): NMi, mi, km, m
   - Depth (below surface): m, ft, fa
   - Height (above reference datum): m, ft (new category)
2. Add Tooltips for unit customization: tooltips for all unit categories in options dialog
3. Tide Display Fix: Tide curves now properly use preferred units from the options dialog.

# Technical changes

1. Use single `fromUsrDistance` function in `navutil_base.cpp` instead of having duplicate code with different sets of units.
2. Add missing units in `fromUsrDistance` implementation.

# Tests

#### **Unit Selection Testing**
- [x] Verify units are organized in Distance/Depth/Height categories in Options > Settings > Display Units
- [x] Test all unit drop-downs save/restore correctly
- [x] Hover over unit labels to verify explanatory tooltips appear

#### **Height Units Testing**
- [x] Set Height format to meters/feet  
- [x] Check tide station displays use height units (not depth units)
- [x] Verify tide curve Y-axis labels match height unit setting
- [x] Test tide predictions window shows correct height units

